### PR TITLE
Implement a plugin mechanic to handle custom mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,33 @@ mock data. Include that in your app:
 
     <script src="build/scenarios.js"></script>
 
+If the generated `build/scenarios.js` is too large, running it on mobile devices might cause memory issues.
+
+You can choose to build multiple files, one for each scenario by specifying 
+`multipleFiles: true` and `dest` as a directory instead of it being a `.js` file.    
+Your Grunt configuration should look something like:
+
+    // load the task
+    grunt.loadNpmTasks('tempo-scenario');
+
+    // configuration for scenarios
+    scenarios: {
+      myApp: {
+        src: 'mocks',
+        dest: 'build/scenarios',
+        multipleFiles: true,
+        baseURL: 'http://myapi.com/',
+        template: 'myTemplate.tpl' // optional
+      }
+    },
+
+Once the task is run, a list of scenario files e.g. 
+`build/scenarios/_default.js` will be generated containing specific mock data. 
+Include all those generated mock files in your app:
+
+    <script src="build/scenarios/_default.js"></script>
+
+
 `scenarioMockDataProvider`
 --------------------------
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,43 @@ The example above defines 2 scenarios `_default` and `loggedIn`. `loggedIn` has
 the default versions of the `Root` and `MobilePhone` resources, but overrides
 `Account`, using the version in `Account/loggedIn.json`.
 
+Custom Response Plugins
+----------------------
+
+If you have some custom functionality to implement for a particular mock, for
+example polling, you can implement it using a plugin. Look at the annotated
+example below to see how to create a plugin. An example is included in this
+repo as well - the 204PollingResponsePlugin.
+
+    angular
+      .module('myPluginModule', ['scenarioResponse'])
+      .config(['mockResponseHandlerProvider',
+        function (mockResponseHandlerProvider) {
+          // You must register your plugin with the mockResponseHandlerProvider.
+          mockResponseHandlerProvider
+            .registerResponsePlugin('myPlugin'); // This must be the name of your service.
+        }
+      ])
+      .factory('pollingResponsePlugin', [function () {
+          var headers = {};
+
+          return {
+            trigger: 'customTrigger', // if an attribute with this name is present in the mock, this plugin will be activated
+            setHeaders: function (_headers) {
+                // headers passed into this function should be added to the response
+              },
+            execute: function (mock) {
+              // the execute function must return a callback function that will be passed into the respond function
+              return function () {
+                // The callback must return an array with 3 values exactly as below
+                return [statusCode, responseBody, headers];
+              }
+            }
+          };
+        }]);
+
+To register this plugin, simply add 'myPluginModule' as a dependency in your app.
+
 Bower Component
 ---------------
 

--- a/app/src/js/mockResponseHandler.js
+++ b/app/src/js/mockResponseHandler.js
@@ -12,14 +12,13 @@ angular
 
       this.$get = ['$injector', function ($injector) {
         return function (mock, mockHeaders) {
+          var plugin,
+          response =  [mock.statusCode, mock.response, mockHeaders];
           for (var i = 0; i < responseHandlerPluginRegistry.length; i++) {
-            var plugin = $injector.get(responseHandlerPluginRegistry[i]);
-            if (mock[plugin['trigger']] !== undefined) {
-              plugin.setHeaders(mockHeaders);
-              return [plugin.execute(mock)];
-            }
-            return [mock.statusCode, mock.response, mockHeaders];
+            plugin = $injector.get(responseHandlerPluginRegistry[i]);
+            response = plugin(response, mock);
           }
+          return response;
         };
       }];
     }]);

--- a/app/src/js/mockResponseHandler.js
+++ b/app/src/js/mockResponseHandler.js
@@ -1,0 +1,25 @@
+/* global angular, _, console */
+
+angular
+  .module('scenarioResponse', [])
+  .provider('mockResponseHandler', [ function () {
+
+      var responseHandlerPluginRegistry = [];
+
+      this.registerResponsePlugin = function (pluginServiceName) {
+        responseHandlerPluginRegistry.push(pluginServiceName);
+      };
+
+      this.$get = ['$injector', function ($injector) {
+        return function (mock, mockHeaders) {
+          for (var i = 0; i < responseHandlerPluginRegistry.length; i++) {
+            var plugin = $injector.get(responseHandlerPluginRegistry[i]);
+            if (mock[plugin['trigger']] !== undefined) {
+              plugin.setHeaders(mockHeaders);
+              return [plugin.execute(mock)];
+            }
+            return [mock.statusCode, mock.response, mockHeaders];
+          }
+        };
+      }];
+    }]);

--- a/app/src/js/mockResponseHandler.spec.js
+++ b/app/src/js/mockResponseHandler.spec.js
@@ -1,0 +1,94 @@
+/* global angular, describe, beforeEach, jasmine, module, inject, it, xit,
+  spyOn, console, expect */
+
+describe('mockResponseHandler', function () {
+  var mockResponseHandler, mockResponseWithTrigger, mockWithoutTrigger,
+    mockPlugin;
+  beforeEach(function () {
+
+    angular.module('pluginTester', ['scenarioResponse'])
+    .config(['mockResponseHandlerProvider',
+        function (mockResponseHandlerProvider) {
+          mockResponseHandlerProvider.registerResponsePlugin('mockPlugin');
+        }]);
+
+    mockResponseWithTrigger =  {
+      'uri': 'http://example.com/test',
+      'httpMethod': 'GET',
+      'statusCode': 200,
+      'mockTrigger': true,
+      'pollCount': 3,
+      'response': {
+        'scenario': 'poll',
+      }
+    };
+    mockWithoutTrigger =  {
+      'uri': 'http://example.com/test',
+      'statusCode': 200,
+      'httpMethod': 'GET',
+      'response': {
+        'scenario': 'standard',
+      }
+    };
+
+    mockPlugin = {
+      trigger: 'mockTrigger',
+      setHeaders: function () {},
+      execute: function () {
+        return 'mockResponse';
+      }
+    };
+    module('pluginTester', function ($provide) {
+        $provide.value('mockPlugin', mockPlugin);
+      });
+
+    inject(function (_mockResponseHandler_) {
+      mockResponseHandler = _mockResponseHandler_;
+    });
+  });
+
+  it('should use a plugin when its trigger parameter is present',
+    function () {
+    // Act.
+    var pluginResponseCallback =
+      mockResponseHandler(mockResponseWithTrigger, {})[0];
+
+    // Assert.
+    expect(pluginResponseCallback).toBe('mockResponse');
+  });
+
+  it('should return the default response value if no trigger is present',
+    function () {
+    // Act.
+    var pluginResponseArray =
+      mockResponseHandler(mockWithoutTrigger, {});
+
+    // Assert.
+    expect(pluginResponseArray).toEqual([200, {scenario: 'standard'}, {}]);
+  });
+
+  it('should use the specified headers for default responses',
+    function () {
+    // Act.
+    var pluginResponseArray =
+      mockResponseHandler(mockWithoutTrigger, {test: 'header'});
+
+    // Assert.
+    expect(pluginResponseArray[2]).toEqual({test: 'header'});
+  });
+
+  it('should pass in the specified headers to the plugin callback',
+    function () {
+    // Arrange.
+    spyOn(mockPlugin, 'setHeaders');
+
+    // Act.
+    var mockHeaders = {test: 'header'};
+    var pluginResponseArray =
+      mockResponseHandler(mockResponseWithTrigger, mockHeaders);
+
+    // Assert.
+    expect(mockPlugin.setHeaders).toHaveBeenCalledWith(mockHeaders);
+  });
+
+});

--- a/app/src/js/mockResponseHandler.spec.js
+++ b/app/src/js/mockResponseHandler.spec.js
@@ -1,9 +1,8 @@
 /* global angular, describe, beforeEach, jasmine, module, inject, it, xit,
-  spyOn, console, expect */
+  spyOn, console, expect, iit */
 
 describe('mockResponseHandler', function () {
-  var mockResponseHandler, mockResponseWithTrigger, mockWithoutTrigger,
-    mockPlugin;
+  var mockResponseHandler, mockResponse, mockPlugin, testHolder;
   beforeEach(function () {
 
     angular.module('pluginTester', ['scenarioResponse'])
@@ -12,7 +11,7 @@ describe('mockResponseHandler', function () {
           mockResponseHandlerProvider.registerResponsePlugin('mockPlugin');
         }]);
 
-    mockResponseWithTrigger =  {
+    mockResponse =  {
       'uri': 'http://example.com/test',
       'httpMethod': 'GET',
       'statusCode': 200,
@@ -22,24 +21,15 @@ describe('mockResponseHandler', function () {
         'scenario': 'poll',
       }
     };
-    mockWithoutTrigger =  {
-      'uri': 'http://example.com/test',
-      'statusCode': 200,
-      'httpMethod': 'GET',
-      'response': {
-        'scenario': 'standard',
-      }
-    };
 
-    mockPlugin = {
-      trigger: 'mockTrigger',
-      setHeaders: function () {},
-      execute: function () {
-        return 'mockResponse';
+    testHolder = {
+      mockPlugin: function (response, mock) {
+        return response;
       }
     };
+    spyOn(testHolder, 'mockPlugin');
     module('pluginTester', function ($provide) {
-        $provide.value('mockPlugin', mockPlugin);
+        $provide.value('mockPlugin', testHolder.mockPlugin);
       });
 
     inject(function (_mockResponseHandler_) {
@@ -47,48 +37,13 @@ describe('mockResponseHandler', function () {
     });
   });
 
-  it('should use a plugin when its trigger parameter is present',
+  it('should call the plugin function',
     function () {
     // Act.
-    var pluginResponseCallback =
-      mockResponseHandler(mockResponseWithTrigger, {})[0];
+    mockResponseHandler(mockResponse, {});
 
     // Assert.
-    expect(pluginResponseCallback).toBe('mockResponse');
-  });
-
-  it('should return the default response value if no trigger is present',
-    function () {
-    // Act.
-    var pluginResponseArray =
-      mockResponseHandler(mockWithoutTrigger, {});
-
-    // Assert.
-    expect(pluginResponseArray).toEqual([200, {scenario: 'standard'}, {}]);
-  });
-
-  it('should use the specified headers for default responses',
-    function () {
-    // Act.
-    var pluginResponseArray =
-      mockResponseHandler(mockWithoutTrigger, {test: 'header'});
-
-    // Assert.
-    expect(pluginResponseArray[2]).toEqual({test: 'header'});
-  });
-
-  it('should pass in the specified headers to the plugin callback',
-    function () {
-    // Arrange.
-    spyOn(mockPlugin, 'setHeaders');
-
-    // Act.
-    var mockHeaders = {test: 'header'};
-    var pluginResponseArray =
-      mockResponseHandler(mockResponseWithTrigger, mockHeaders);
-
-    // Assert.
-    expect(mockPlugin.setHeaders).toHaveBeenCalledWith(mockHeaders);
+    expect(testHolder.mockPlugin).toHaveBeenCalled();
   });
 
 });

--- a/app/src/js/plugins/204PollingResponsePlugin.js
+++ b/app/src/js/plugins/204PollingResponsePlugin.js
@@ -9,25 +9,26 @@ angular
   ])
   .factory('pollingResponsePlugin', [function () {
       var headers = {};
+      var pollCounter = 0;
 
-      return {
-        trigger: 'poll',
-        setHeaders: function (_headers_) {
-          headers = _headers_;
-        },
-
-        execute: function (mock) {
-          var pollCounter = 0;
-          var pollCount = _.has(mock, 'pollCount') ? mock.pollCount : 2;
-
-          return function () {
-            pollCounter++;
-            if (pollCounter < pollCount) {
-              return [204, {}, headers];
-            }
-            pollCounter = 0;
-            return [mock.statusCode, mock.response, headers];
-          };
+      return function (responseArray, mock) {
+        if (typeof mock.poll === undefined || mock.poll === false) {
+          return responseArray;
         }
+        var pollCount = _.has(mock, 'pollCount') ? mock.pollCount : 2;
+        if (typeof mock.headers !== undefined) {
+          headers = _.merge(headers, mock.headers);
+        }
+
+        return (function () {
+          pollCounter++;
+          if (pollCounter < pollCount) {
+            return [204, {}, headers];
+          }
+          pollCounter = 0;
+
+          return responseArray;
+        }).call();
+
       };
     }]);

--- a/app/src/js/plugins/204PollingResponsePlugin.js
+++ b/app/src/js/plugins/204PollingResponsePlugin.js
@@ -1,0 +1,33 @@
+/* global angular, _, console */
+angular
+  .module('pollingScenarioPlugin', ['scenarioResponse'])
+  .config(['mockResponseHandlerProvider',
+    function (mockResponseHandlerProvider) {
+      mockResponseHandlerProvider
+        .registerResponsePlugin('pollingResponsePlugin');
+    }
+  ])
+  .factory('pollingResponsePlugin', [function () {
+      var headers = {};
+
+      return {
+        trigger: 'poll',
+        setHeaders: function (_headers_) {
+          headers = _headers_;
+        },
+
+        execute: function (mock) {
+          var pollCounter = 0;
+          var pollCount = _.has(mock, 'pollCount') ? mock.pollCount : 2;
+
+          return function () {
+            pollCounter++;
+            if (pollCounter < pollCount) {
+              return [204, {}, headers];
+            }
+            pollCounter = 0;
+            return [mock.statusCode, mock.response, headers];
+          };
+        }
+      };
+    }]);

--- a/app/src/js/plugins/204PollingResponsePlugin.spec.js
+++ b/app/src/js/plugins/204PollingResponsePlugin.spec.js
@@ -1,8 +1,11 @@
-/* global describe, beforeEach, module, inject, it, expect */
+/* global describe, console, beforeEach, module, inject, it, expect, iit */
 
 describe('pollingScenarioPlugin', function () {
-  var pollingResponsePlugin, mockResponse, mockWithoutPollCountSet;
+  var pollingResponsePlugin, mockResponse, mockWithoutPollCountSet,
+    responseArray;
+
   beforeEach(function () {
+
 
     mockResponse =  {
       'uri': 'http://example.com/test',
@@ -23,6 +26,8 @@ describe('pollingScenarioPlugin', function () {
         'scenario': 'poll',
       }
     };
+    responseArray = [200, mockResponse.response, []];
+
     module('pollingScenarioPlugin');
     inject(function (_pollingResponsePlugin_) {
       pollingResponsePlugin = _pollingResponsePlugin_;
@@ -31,7 +36,8 @@ describe('pollingScenarioPlugin', function () {
 
   it('should return a 204 http status code on the first request', function () {
     // Act.
-    var mockResponseArray = pollingResponsePlugin.execute().apply();
+    var mockResponseArray =
+      pollingResponsePlugin(mockResponseArray, mockResponse);
 
     // Assert.
     expect(mockResponseArray[0]).toBe(204);
@@ -39,12 +45,12 @@ describe('pollingScenarioPlugin', function () {
 
   it('should return a 200 http status code on the third request', function () {
     // Arrange.
-    var mockResponseCallback = pollingResponsePlugin.execute(mockResponse);
-    mockResponseCallback.apply();
-    mockResponseCallback.apply();
+    pollingResponsePlugin(responseArray, mockResponse);
+    pollingResponsePlugin(responseArray, mockResponse);
 
     // Act.
-    var mockResponseArray = mockResponseCallback.apply();
+    var mockResponseArray =
+      pollingResponsePlugin(responseArray, mockResponse);
 
     // Assert.
     expect(mockResponseArray[0]).toBe(200);
@@ -52,24 +58,22 @@ describe('pollingScenarioPlugin', function () {
 
   it('should expected polling twice by default', function () {
     // Arrange.
-    var mockResponseCallback = pollingResponsePlugin
-    .execute(mockWithoutPollCountSet);
-    mockResponseCallback.apply();
+    pollingResponsePlugin(responseArray, mockWithoutPollCountSet);
 
     // Act.
-    var mockResponseArray = mockResponseCallback.apply();
+    var mockResponseArray =
+      pollingResponsePlugin(responseArray, mockWithoutPollCountSet);
 
     // Assert.
     expect(mockResponseArray[0]).toBe(200);
   });
 
-  it('should allow headers to be set for mock responses', function () {
+  it('should add headers from the mock response', function () {
     // Arrange.
-    pollingResponsePlugin.setHeaders({'test': 'header'});
-    var mockResponseCallback = pollingResponsePlugin.execute(mockResponse);
+    mockResponse.headers = {'test': 'header'};
 
     // Act.
-    var mockResponseArray = mockResponseCallback.apply();
+    var mockResponseArray = pollingResponsePlugin(responseArray, mockResponse);
 
     // Assert.
     expect(mockResponseArray[2].test).toBe('header');

--- a/app/src/js/plugins/204PollingResponsePlugin.spec.js
+++ b/app/src/js/plugins/204PollingResponsePlugin.spec.js
@@ -1,0 +1,78 @@
+/* global describe, beforeEach, module, inject, it, expect */
+
+describe('pollingScenarioPlugin', function () {
+  var pollingResponsePlugin, mockResponse, mockWithoutPollCountSet;
+  beforeEach(function () {
+
+    mockResponse =  {
+      'uri': 'http://example.com/test',
+      'httpMethod': 'GET',
+      'statusCode': 200,
+      'poll': true,
+      'pollCount': 3,
+      'response': {
+        'scenario': 'poll',
+      }
+    };
+    mockWithoutPollCountSet =  {
+      'uri': 'http://example.com/test',
+      'httpMethod': 'GET',
+      'statusCode': 200,
+      'poll': true,
+      'response': {
+        'scenario': 'poll',
+      }
+    };
+    module('pollingScenarioPlugin');
+    inject(function (_pollingResponsePlugin_) {
+      pollingResponsePlugin = _pollingResponsePlugin_;
+    });
+  });
+
+  it('should return a 204 http status code on the first request', function () {
+    // Act.
+    var mockResponseArray = pollingResponsePlugin.execute().apply();
+
+    // Assert.
+    expect(mockResponseArray[0]).toBe(204);
+  });
+
+  it('should return a 200 http status code on the third request', function () {
+    // Arrange.
+    var mockResponseCallback = pollingResponsePlugin.execute(mockResponse);
+    mockResponseCallback.apply();
+    mockResponseCallback.apply();
+
+    // Act.
+    var mockResponseArray = mockResponseCallback.apply();
+
+    // Assert.
+    expect(mockResponseArray[0]).toBe(200);
+  });
+
+  it('should expected polling twice by default', function () {
+    // Arrange.
+    var mockResponseCallback = pollingResponsePlugin
+    .execute(mockWithoutPollCountSet);
+    mockResponseCallback.apply();
+
+    // Act.
+    var mockResponseArray = mockResponseCallback.apply();
+
+    // Assert.
+    expect(mockResponseArray[0]).toBe(200);
+  });
+
+  it('should allow headers to be set for mock responses', function () {
+    // Arrange.
+    pollingResponsePlugin.setHeaders({'test': 'header'});
+    var mockResponseCallback = pollingResponsePlugin.execute(mockResponse);
+
+    // Act.
+    var mockResponseArray = mockResponseCallback.apply();
+
+    // Assert.
+    expect(mockResponseArray[2].test).toBe('header');
+  });
+
+});

--- a/app/src/js/scenario.spec.js
+++ b/app/src/js/scenario.spec.js
@@ -1,4 +1,5 @@
-/* global describe, beforeEach, jasmine, module, inject, it, xit, expect */
+/* global angular, describe, beforeEach, jasmine, module, inject, it, xit,
+  expect */
 
 describe('scenario', function () {
   var mockHttpBackend, mockWindow, scenarioMockDataProvider, scenarioMockData,
@@ -56,7 +57,8 @@ describe('scenario', function () {
 
   describe('scenarioName', function () {
     beforeEach(function () {
-      module('scenario');
+      angular.module('testPlugins', ['scenario', 'pollingScenarioPlugin']);
+      module('testPlugins');
       inject(function (_scenarioName_) {
         scenarioName = _scenarioName_;
       });
@@ -76,8 +78,9 @@ describe('scenario', function () {
 
   describe('scenarioMockDataProvider', function () {
     beforeEach(function () {
+      angular.module('testPlugins', ['scenario', 'pollingScenarioPlugin']);
       module(
-        'scenario',
+        'testPlugins',
         function ($provide, _scenarioMockDataProvider_) {
           $provide.value('$httpBackend', mockHttpBackend);
           scenarioMockDataProvider = _scenarioMockDataProvider_;
@@ -137,8 +140,9 @@ describe('scenario', function () {
   describe('scenarioMocks', function () {
     var setupScenarioMocks = function (mockData) {
       mockWindow = {location: {search: '?scenario=scenario2'}};
+      angular.module('testPlugins', ['scenario', 'pollingScenarioPlugin']);
       module(
-        'scenario',
+        'testPlugins',
         function ($provide, _scenarioMockDataProvider_) {
           $provide.value('$httpBackend', mockHttpBackend);
           $provide.value('$window', mockWindow);

--- a/app/src/js/scenario.spec.js
+++ b/app/src/js/scenario.spec.js
@@ -121,8 +121,6 @@ describe('scenario', function () {
       var mockResource = scenario2[0];
       expect(mockHttpBackend.when).toHaveBeenCalledWith(
         mockResource.httpMethod, mockResource.uri, mockResource.requestData);
-      expect(mockHttpBackend.respond).toHaveBeenCalledWith(
-        mockResource.statusCode, mockResource.response, jasmine.any(Object));
     });
 
     it('should allow a client app to set the default scenario', function () {
@@ -161,8 +159,6 @@ describe('scenario', function () {
       var mockResource = scenario2[0];
       expect(mockHttpBackend.when).toHaveBeenCalledWith(
         mockResource.httpMethod, mockResource.uri, mockResource.requestData);
-      expect(mockHttpBackend.respond).toHaveBeenCalledWith(
-        mockResource.statusCode, mockResource.response, jasmine.any(Object));
     });
 
     it('should do nothing if the specified scenario isn\'t found', function () {
@@ -184,8 +180,6 @@ describe('scenario', function () {
       var mockResource = scenario2[0];
       expect(mockHttpBackend.when).toHaveBeenCalledWith(
         mockResource.httpMethod, mockResource.uri, mockResource.requestData);
-      expect(mockHttpBackend.respond)
-        .toHaveBeenCalledWith(jasmine.any(Function));
     });
   });
 });

--- a/tasks/multipleFilesScenarioData.tpl
+++ b/tasks/multipleFilesScenarioData.tpl
@@ -1,0 +1,22 @@
+/* global angular, exports, module */
+
+(function (root, name, factory) {
+  if (typeof angular === "object" && angular.module) {
+    angular
+      .module("scenario")
+      .config([
+        "scenarioMockDataProvider",
+        function (scenarioMockDataProvider) {
+          scenarioMockDataProvider.setDefaultScenario("_default");
+          scenarioMockDataProvider.addMockData(name, factory());
+        }
+      ]);
+  } else if (typeof exports === "object") {
+    module.exports = factory();
+  }
+})(this, "<%= scenarioDataName %>", function () {
+      /* jshint ignore:start */
+      return <%= scenarioData %>;
+      /* jshint ignore:end */
+  }
+);


### PR DESCRIPTION
This is a starting point to provide a mechanism to add custom mock handlers in user land rather than adding loads of domain specific logic to the tempo-scenario library. The functionality added by @morrislaptop [here](https://github.com/QuickbridgeLtd/tempo-scenario/pull/5) could plausibly be implemented as a plugin too. 

This is a breaking change for ivy, and to implement this you'd need to add 'pollingScenarioPlugin' as a module dependency in your dev module.

Suggestions welcome. 
